### PR TITLE
Update Mekanism Extras compatibility for 1.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,8 @@ dependencies {
     implementation fg.deobf("curse.maven:evolved-mekanism-1230085:${evolved_mekanism_file}")
 
     implementation fg.deobf("mezz.jei:jei-${mc_version}-forge:${jei_version}")
-    implementation fg.deobf("dev.emi:emi-forge:${emi_version}+${mc_version}")
+    //implementation fg.deobf("dev.emi:emi-forge:${emi_version}+${mc_version}")
+    implementation fg.deobf("curse.maven:emi-580555:${emi_file}")
 
     // Runtiem Only
     runtimeOnly fg.deobf("curse.maven:refined-storage-243076:${refined_storage_file}")

--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,8 @@ def intoTargets = ["$rootDir/out/production/resources/", "$rootDir/out/productio
 def replaceProperties = [mc_version: mc_version,
 	mod_id: mod_id, mod_version: mod_version, mod_name: mod_name, mod_description: mod_description, mod_license: mod_license, mod_homepage: mod_homepage, mod_source: mod_source, mod_issues: mod_issues,
 	forge_api_version: forge_api_version, forge_loader_version: forge_loader_version,
-	mekanism_version: mekanism_version, mekanism_version_range: mekanism_version_range
+	mekanism_version: mekanism_version, mekanism_version_range: mekanism_version_range,
+	mekanism_extra_version_range: mekanism_extra_version_range
 ]
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,8 @@ mekanism_version=10.4.16.80
 mekanism_version_range=[10.4.0,)
 jei_version=15.20.0.106
 better_fusion_file=5550305
-mekanism_extra_file=6936409
+mekanism_extra_file=8247562
+mekanism_extra_version_range=[1.5.0,1.20.1)
 iglee_library_file=6987117
 evolved_mekanism_file=7599591
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@ mekanism_version_range=[10.4.0,)
 jei_version=15.20.0.106
 better_fusion_file=5550305
 mekanism_extra_file=8247562
-mekanism_extra_version_range=[1.5.0,1.20.1)
+mekanism_extra_version_range=[1.5.0,)
 iglee_library_file=6987117
 evolved_mekanism_file=7599591
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,3 +36,4 @@ evolved_mekanism_file=7599591
 refined_storage_file=4630564
 jade_file=4573193
 emi_version=1.1.19
+emi_file=6075448

--- a/src/main/java/giselle/jei_mekanism_multiblocks/client/jei/category/extras/ExtraMatrixCategory.java
+++ b/src/main/java/giselle/jei_mekanism_multiblocks/client/jei/category/extras/ExtraMatrixCategory.java
@@ -3,7 +3,7 @@ package giselle.jei_mekanism_multiblocks.client.jei.category.extras;
 import java.util.function.Consumer;
 
 import com.jerry.mekanism_extras.MekanismExtras;
-import com.jerry.mekanism_extras.common.registry.ExtraBlock;
+import com.jerry.mekanism_extras.common.registries.ExtraBlocks;
 
 import giselle.jei_mekanism_multiblocks.client.gui.IntSliderWidget;
 import giselle.jei_mekanism_multiblocks.client.gui.IntSliderWithButtons;
@@ -24,25 +24,25 @@ public class ExtraMatrixCategory extends MultiblockCategory<ExtraMatrixCategory.
 {
 	public ExtraMatrixCategory(IGuiHelper helper)
 	{
-		super(helper, MekanismExtras.rl("matrix"), MatrixWidget.class, Component.translatable("text.jei_mekanism_multiblocks.building.extra_matrix"), ExtraBlock.REINFORCED_INDUCTION_PORT.getItemStack());
+		super(helper, MekanismExtras.rl("matrix"), MatrixWidget.class, Component.translatable("text.jei_mekanism_multiblocks.building.extra_matrix"), ExtraBlocks.REINFORCED_INDUCTION_PORT.getItemStack());
 	}
 
 	@Override
 	protected void getRecipeCatalystItemStacks(Consumer<ItemStack> consumer)
 	{
 		super.getRecipeCatalystItemStacks(consumer);
-		consumer.accept(ExtraBlock.REINFORCED_INDUCTION_CASING.getItemStack());
-		consumer.accept(ExtraBlock.REINFORCED_INDUCTION_PORT.getItemStack());
+		consumer.accept(ExtraBlocks.REINFORCED_INDUCTION_CASING.getItemStack());
+		consumer.accept(ExtraBlocks.REINFORCED_INDUCTION_PORT.getItemStack());
 		consumer.accept(MekanismBlocks.STRUCTURAL_GLASS.getItemStack());
 
-		consumer.accept(ExtraBlock.ABSOLUTE_INDUCTION_CELL.getItemStack());
-		consumer.accept(ExtraBlock.ABSOLUTE_INDUCTION_PROVIDER.getItemStack());
-		consumer.accept(ExtraBlock.SUPREME_INDUCTION_CELL.getItemStack());
-		consumer.accept(ExtraBlock.SUPREME_INDUCTION_PROVIDER.getItemStack());
-		consumer.accept(ExtraBlock.COSMIC_INDUCTION_CELL.getItemStack());
-		consumer.accept(ExtraBlock.COSMIC_INDUCTION_PROVIDER.getItemStack());
-		consumer.accept(ExtraBlock.INFINITE_INDUCTION_CELL.getItemStack());
-		consumer.accept(ExtraBlock.INFINITE_INDUCTION_PROVIDER.getItemStack());
+		consumer.accept(ExtraBlocks.ABSOLUTE_INDUCTION_CELL.getItemStack());
+		consumer.accept(ExtraBlocks.ABSOLUTE_INDUCTION_PROVIDER.getItemStack());
+		consumer.accept(ExtraBlocks.SUPREME_INDUCTION_CELL.getItemStack());
+		consumer.accept(ExtraBlocks.SUPREME_INDUCTION_PROVIDER.getItemStack());
+		consumer.accept(ExtraBlocks.COSMIC_INDUCTION_CELL.getItemStack());
+		consumer.accept(ExtraBlocks.COSMIC_INDUCTION_PROVIDER.getItemStack());
+		consumer.accept(ExtraBlocks.INFINITE_INDUCTION_CELL.getItemStack());
+		consumer.accept(ExtraBlocks.INFINITE_INDUCTION_PROVIDER.getItemStack());
 	}
 
 	public static class MatrixWidget extends MultiblockWidget
@@ -106,8 +106,8 @@ public class ExtraMatrixCategory extends MultiblockCategory<ExtraMatrixCategory.
 				glasses = 0;
 			}
 
-			consumer.accept(new ItemStack(ExtraBlock.REINFORCED_INDUCTION_CASING, casing));
-			consumer.accept(new ItemStack(ExtraBlock.REINFORCED_INDUCTION_PORT, ports));
+			consumer.accept(new ItemStack(ExtraBlocks.REINFORCED_INDUCTION_CASING, casing));
+			consumer.accept(new ItemStack(ExtraBlocks.REINFORCED_INDUCTION_PORT, ports));
 			consumer.accept(new ItemStack(this.getGlassBlock(), glasses));
 		}
 

--- a/src/main/java/giselle/jei_mekanism_multiblocks/client/jei/category/extras/NaquadahReactorCategory.java
+++ b/src/main/java/giselle/jei_mekanism_multiblocks/client/jei/category/extras/NaquadahReactorCategory.java
@@ -5,10 +5,10 @@ import java.util.function.Consumer;
 
 import com.jerry.generator_extras.common.ExtraGenLang;
 import com.jerry.generator_extras.common.config.GenLoadConfig;
-import com.jerry.generator_extras.common.genregistry.ExtraGenBlocks;
-import com.jerry.generator_extras.common.genregistry.ExtraGenItem;
+import com.jerry.generator_extras.common.genregistries.ExtraGenBlocks;
+import com.jerry.generator_extras.common.genregistries.ExtraGenItem;
 import com.jerry.mekanism_extras.MekanismExtras;
-import com.jerry.mekanism_extras.common.ExtraTag;
+import com.jerry.mekanism_extras.common.ExtraTags;
 
 import giselle.jei_mekanism_multiblocks.client.gui.CheckBoxWidget;
 import giselle.jei_mekanism_multiblocks.client.gui.IntSliderWidget;
@@ -45,7 +45,7 @@ public class NaquadahReactorCategory extends MultiblockCategory<NaquadahReactorC
 		consumer.accept(ExtraGenBlocks.LEAD_COATED_LASER_FOCUS_MATRIX.getItemStack());
 		consumer.accept(ExtraGenBlocks.LEAD_COATED_GLASS.getItemStack());
 
-		List<Gas> fusionFuelGases = ChemicalTags.GAS.getManager().get().getTag(ExtraTag.Gases.NAQUADAH_URANIUM_FUEL).stream().toList();
+		List<Gas> fusionFuelGases = ChemicalTags.GAS.getManager().get().getTag(ExtraTags.Gases.NAQUADAH_URANIUM_FUEL).stream().toList();
 		long capacity = GenLoadConfig.generatorConfig.hohlraumMaxGas.get();
 
 		for (Gas gas : fusionFuelGases)

--- a/src/main/java/giselle/jei_mekanism_multiblocks/client/mixin/emi/JemiPluginMixin.java
+++ b/src/main/java/giselle/jei_mekanism_multiblocks/client/mixin/emi/JemiPluginMixin.java
@@ -48,9 +48,7 @@ public abstract class JemiPluginMixin
 
 			if (emiCategory == null)
 			{
-				JEI_MekanismMultiblocks.LOGGER.error(
-						"Skipping EMI recipe for unregistered JEI category: {}",
-						jeiCategory.getClass().getName());
+				JEI_MekanismMultiblocks.LOGGER.error("Skipping EMI recipe for unregistered JEI category: {}", jeiCategory.getClass().getName());
 				continue;
 			}
 

--- a/src/main/java/giselle/jei_mekanism_multiblocks/client/mixin/emi/JemiPluginMixin.java
+++ b/src/main/java/giselle/jei_mekanism_multiblocks/client/mixin/emi/JemiPluginMixin.java
@@ -18,6 +18,7 @@ import giselle.jei_mekanism_multiblocks.client.emi.EMIMultiblockRecipe;
 import giselle.jei_mekanism_multiblocks.client.jei.JeiPlugin;
 import giselle.jei_mekanism_multiblocks.client.jei.MultiblockCategory;
 import giselle.jei_mekanism_multiblocks.client.jei.MultiblockWidget;
+import giselle.jei_mekanism_multiblocks.common.JEI_MekanismMultiblocks;
 import mezz.jei.api.recipe.category.IRecipeCategory;
 
 @Mixin(value = JemiPlugin.class, remap = false)
@@ -43,7 +44,17 @@ public abstract class JemiPluginMixin
 
 		for (MultiblockCategory<? extends MultiblockWidget> jeiCategory : JeiPlugin.instance().getCategories())
 		{
-			registry.addRecipe(this.createRecipe(jeiCategory, reverse.get(jeiCategory)));
+			EmiRecipeCategory emiCategory = reverse.get(jeiCategory);
+
+			if (emiCategory == null)
+			{
+				JEI_MekanismMultiblocks.LOGGER.error(
+						"Skipping EMI recipe for unregistered JEI category: {}",
+						jeiCategory.getClass().getName());
+				continue;
+			}
+
+			registry.addRecipe(this.createRecipe(jeiCategory, emiCategory));
 		}
 
 	}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -39,3 +39,10 @@ issueTrackerURL="${mod_issues}"
     versionRange="${mekanism_version_range}"
     ordering="NONE"
     side="BOTH"
+
+[[dependencies.${mod_id}]]
+    modId="mekanism_extras"
+    mandatory=false
+    versionRange="${mekanism_extra_version_range}"
+    ordering="NONE"
+    side="CLIENT"


### PR DESCRIPTION
## Summary

* Update Mekanism Extras integration for 1.5.0.
* Require Mekanism Extras 1.5.0 or newer when installed.
* Skip EMI recipe registration when the corresponding JEMI category is unavailable.

Closes #38.

## Testing

Verified with:

* Mekanism Extras 1.5.0
* Mekanism Generators
* JEI and EMI
* No Mekanism Extras installed

All affected multiblock categories loaded correctly, and EMI no longer received recipes with a null category.
